### PR TITLE
fix(make): add C flags required by GCC 14 and later

### DIFF
--- a/GccUnix.mak
+++ b/GccUnix.mak
@@ -14,7 +14,7 @@ bitopts = -DLONG_IS_64BITS
 #bitopts = -m32
 
 ifeq ($(DEBUG),0)
-extra_c_flags = -DNDEBUG -O2
+extra_c_flags = -DNDEBUG -O2 -Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration
 outd_suffix=R
 else
 extra_c_flags = -D_INT_DEBUG -g


### PR DESCRIPTION
As of GCC 14, the compiler is more strict with some things.

Speficially, incompatible pointer types and implicit function declarations are treated by errors by default.

This adds flags to the Linux/Unix Makefile so that the code builds with newer GCC versions again.

Tested with GCC 14 and GCC 15.
